### PR TITLE
chore(benchmark): add `{ __proto: null }` case

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ console.log(Object.getPrototypeOf(obj)) // ==> null (via prototype chain)
 ## Benchmark
 
 ```
-NullProtoObj via constructor x 296,220,603 ops/sec ±5.23% (74 runs sampled)
-Object.create(null) x 78,571,005 ops/sec ±1.32% (93 runs sampled)
-{} (normal object) x 292,647,799 ops/sec ±4.96% (76 runs sampled)
-Fastest is NullProtoObj via constructor,{} (normal object)
+NullProtoObj via constructor x 207,586,282 ops/sec ±4.80% (81 runs sampled)
+Object.create(null) x 54,415,324 ops/sec ±2.01% (89 runs sampled)
+{} (normal object) x 194,340,713 ops/sec ±5.15% (77 runs sampled)
+{__proto__:null} x 39,313,923 ops/sec ±2.37% (92 runs sampled)
+Fastest is NullProtoObj via constructor
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ NullProtoObj via constructor x 207,586,282 ops/sec ±4.80% (81 runs sampled)
 Object.create(null) x 54,415,324 ops/sec ±2.01% (89 runs sampled)
 {} (normal object) x 194,340,713 ops/sec ±5.15% (77 runs sampled)
 {__proto__:null} x 39,313,923 ops/sec ±2.37% (92 runs sampled)
+
 Fastest is NullProtoObj via constructor
 ```
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,8 +1,9 @@
 # Benchmark
 
 ```
-NullProtoObj via constructor x 296,220,603 ops/sec ±5.23% (74 runs sampled)
-Object.create(null) x 78,571,005 ops/sec ±1.32% (93 runs sampled)
-{} (normal object) x 292,647,799 ops/sec ±4.96% (76 runs sampled)
-Fastest is NullProtoObj via constructor,{} (normal object)
+NullProtoObj via constructor x 207,586,282 ops/sec ±4.80% (81 runs sampled)
+Object.create(null) x 54,415,324 ops/sec ±2.01% (89 runs sampled)
+{} (normal object) x 194,340,713 ops/sec ±5.15% (77 runs sampled)
+{__proto__:null} x 39,313,923 ops/sec ±2.37% (92 runs sampled)
+Fastest is NullProtoObj via constructor
 ```

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -5,5 +5,6 @@ NullProtoObj via constructor x 207,586,282 ops/sec ±4.80% (81 runs sampled)
 Object.create(null) x 54,415,324 ops/sec ±2.01% (89 runs sampled)
 {} (normal object) x 194,340,713 ops/sec ±5.15% (77 runs sampled)
 {__proto__:null} x 39,313,923 ops/sec ±2.37% (92 runs sampled)
+
 Fastest is NullProtoObj via constructor
 ```

--- a/benchmark/index.js
+++ b/benchmark/index.js
@@ -20,6 +20,10 @@ suite
     const obj = {}
     obj.foo = 123
   })
+  .add('{__proto__:null}', function () {
+    const obj = { __proto__: null }
+    obj.foo = 123
+  })
   .on('cycle', function (event) {
     console.log(String(event.target))
   })


### PR DESCRIPTION
So I am just tired of @magic-akari and @mmis1000 and @jack-works asking me why not `{ __proto: null }`, so I updated the benchmark in the PR.

I have enabled `Allow edits by maintainers` so you can update the `README.md` file in my branch before merging this.

Also here is my run:

```
NullProtoObj via constructor x 207,586,282 ops/sec ±4.80% (81 runs sampled)
Object.create(null) x 54,415,324 ops/sec ±2.01% (89 runs sampled)
{} (normal object) x 194,340,713 ops/sec ±5.15% (77 runs sampled)
{__proto__:null} x 39,313,923 ops/sec ±2.37% (92 runs sampled)
Fastest is NullProtoObj via constructor
```

`{ __proto: null }` is even 40% slower than `Object.create(null)`.